### PR TITLE
catch rtpp error, rtp_local: fix typo

### DIFF
--- a/sippy/Rtp_proxy_client_local.py
+++ b/sippy/Rtp_proxy_client_local.py
@@ -35,7 +35,7 @@ class Rtp_proxy_client_local(Rtp_proxy_client_stream):
       bind_address = None, nworkers = 1):
         Rtp_proxy_client_stream.__init__(self, global_config = global_config, \
           address = address, bind_address = bind_address, nworkers = nworkers, \
-          family == socket.AF_UNIX)
+          family = socket.AF_UNIX)
 
 if __name__ == '__main__':
     from twisted.internet import reactor

--- a/sippy/Rtp_proxy_session.py
+++ b/sippy/Rtp_proxy_session.py
@@ -104,7 +104,7 @@ class _rtpps_side(object):
             return
         t1 = result.split()
         if t1[0][0] == 'E':
-            result_callback(None, *callback_parameters)
+            result_callback(None, rtpps, *cpo.callback_parameters)
             return
         rtpproxy_port = int(t1[0])
         if rtpproxy_port == 0:

--- a/sippy/Rtp_proxy_session.py
+++ b/sippy/Rtp_proxy_session.py
@@ -103,6 +103,9 @@ class _rtpps_side(object):
             result_callback(None, rtpps, *cpo.callback_parameters)
             return
         t1 = result.split()
+        if t1[0][0] == 'E':
+            result_callback(None, *callback_parameters)
+            return
         rtpproxy_port = int(t1[0])
         if rtpproxy_port == 0:
             result_callback(None, rtpps, *cpo.callback_parameters)


### PR DESCRIPTION
On rtpproxy side no sockets:
DBUG:get_command:GLOBAL: received command "43f5bd8fb40af5f0f9d6b0a4b2f73c2e U 1382950906-0 192.168.1.2 15234 1442640158"
INFO:rtpp_command_ul_handle:GLOBAL: new session 1382950906-0, tag 1442640158 requested, type strong
ERR:rtpp_command_ul_handle:GLOBAL: can't create listener
DBUG:rtpc_doreply:GLOBAL: sending reply "E72
"
On b2bua side:
2016-04-28 16:35:17+0300 [-] 2016-04-28 16:35:17.757193 Udp_server: unhandled exception when processing incoming data
2016-04-28 16:35:17+0300 [-] ----------------------------------------------------------------------
2016-04-28 16:35:17+0300 [-] Traceback (most recent call last):
2016-04-28 16:35:17+0300 [-]   File "/home/me/b2bua/sippy/Udp_server.py", line 228, in handle_read
2016-04-28 16:35:17+0300 [-]     self.uopts.data_callback(data, address, self, rtime)
2016-04-28 16:35:17+0300 [-]   File "/home/me/b2bua/sippy/Rtp_proxy_client_udp.py", line 128, in process_reply
2016-04-28 16:35:17+0300 [-]     result_callback(result.strip(), *callback_parameters)
2016-04-28 16:35:17+0300 [-]   File "/home/me/b2bua/sippy/Rtp_proxy_session.py", line 227, in update_result
2016-04-28 16:35:17+0300 [-]     rtpproxy_port = int(t1[0])
2016-04-28 16:35:17+0300 [-] ValueError: invalid literal for int() with base 10: 'E72'
