### PR TITLE
Add support for 300 Multiple Choices response.

### DIFF
--- a/sippy/SipAddress.py
+++ b/sippy/SipAddress.py
@@ -45,6 +45,7 @@ class SipAddress(object):
     params_order = None
     hadbrace = None
     transtable = maketrans('-.!%*_+`\'~', 'a' * 10)
+    q = None
 
     def __init__(self, address = None, name = None, url = None, params = None,
       hadbrace = None, params_order = None, relaxedparser = False):
@@ -163,3 +164,11 @@ class SipAddress(object):
     def delParam(self, name):
         del self.params[name]
         self.params_order.remove(name)
+
+    def getQ(self):
+        if self.q == None:
+            try:
+                self.q = float(self.params['q'])
+            except:
+                self.q = 1.0
+        return self.q

--- a/sippy/SipAddress.py
+++ b/sippy/SipAddress.py
@@ -45,7 +45,6 @@ class SipAddress(object):
     params_order = None
     hadbrace = None
     transtable = maketrans('-.!%*_+`\'~', 'a' * 10)
-    q = None
 
     def __init__(self, address = None, name = None, url = None, params = None,
       hadbrace = None, params_order = None, relaxedparser = False):
@@ -164,11 +163,3 @@ class SipAddress(object):
     def delParam(self, name):
         del self.params[name]
         self.params_order.remove(name)
-
-    def getQ(self):
-        if self.q == None:
-            try:
-                self.q = float(self.params['q'])
-            except:
-                self.q = 1.0
-        return self.q

--- a/sippy/UA.py
+++ b/sippy/UA.py
@@ -291,13 +291,14 @@ class UA(object):
         self.reqs[self.lCSeq] = req
         return req
 
-    def sendUasResponse(self, scode, reason, body = None, contact = None, \
+    def sendUasResponse(self, scode, reason, body = None, contacts = None, \
       reason_rfc3326 = None, extra_headers = None, ack_wait = False):
         uasResp = self.uasResp.getCopy()
         uasResp.setSCode(scode, reason)
         uasResp.setBody(body)
-        if contact != None:
-            uasResp.appendHeader(SipHeader(name = 'contact', body = contact))
+        if contacts != None:
+            for contact in contacts:
+                uasResp.appendHeader(SipHeader(name = 'contact', body = contact))
         if reason_rfc3326 != None:
             uasResp.appendHeader(SipHeader(body = reason_rfc3326))
         if extra_headers != None:

--- a/sippy/UaStateConnected.py
+++ b/sippy/UaStateConnected.py
@@ -56,8 +56,8 @@ class UaStateConnected(UaStateGeneric):
                 self.ua.global_config['_sip_tm'].sendResponse(req.genResponse(400, 'Bad Request', server = self.ua.local_ua))
                 return None
             self.ua.global_config['_sip_tm'].sendResponse(req.genResponse(202, 'Accepted', server = self.ua.local_ua))
-            also = req.getHFBody('refer-to').getCopy()
-            self.ua.equeue.append(CCEventDisconnect([ also ], rtime = req.rtime, origin = self.ua.origin))
+            also = req.getHFBody('refer-to').getUrl().getCopy()
+            self.ua.equeue.append(CCEventDisconnect(also, rtime = req.rtime, origin = self.ua.origin))
             self.ua.recvEvent(CCEventDisconnect(rtime = req.rtime, origin = self.ua.origin))
             return None
         if req.getMethod() == 'INVITE':
@@ -98,7 +98,7 @@ class UaStateConnected(UaStateGeneric):
             self.ua.global_config['_sip_tm'].sendResponse(req.genResponse(200, 'OK', server = self.ua.local_ua))
             #print 'BYE received in the Connected state, going to the Disconnected state'
             if req.countHFs('also') > 0:
-                also = [ req.getHFBody('also').getCopy() ]
+                also = req.getHFBody('also').getUrl().getCopy()
             else:
                 also = None
             event = CCEventDisconnect(also, rtime = req.rtime, origin = self.ua.origin)
@@ -150,14 +150,19 @@ class UaStateConnected(UaStateGeneric):
     def recvEvent(self, event):
         if isinstance(event, CCEventDisconnect) or isinstance(event, CCEventFail) or isinstance(event, CCEventRedirect):
             #print 'event', event, 'received in the Connected state sending BYE'
-            if not isinstance(event, CCEventFail):
+            redirect = None
+            if isinstance(event, CCEventDisconnect):
+                redirect = event.getData()
+                if redirect != None:
+                    redirect = SipAddress(url = redirect)
+            elif isinstance(event, CCEventRedirect):
                 redirects = event.getData()
-            else:
-                redirects = None
-            if redirects != None and self.ua.useRefer:
+                if redirects != None:
+                    redirect = redirects[0]
+            if redirect != None and self.ua.useRefer:
                 req = self.ua.genRequest('REFER', reason = event.reason)
                 self.ua.lCSeq += 1
-                also = SipReferTo(redirects[0])
+                also = SipReferTo(address = redirect)
                 req.appendHeader(SipHeader(name = 'refer-to', body = also))
                 rby = SipReferredBy(address = SipAddress(url = self.ua.lUri.getUrl()))
                 req.appendHeader(SipHeader(name = 'referred-by', body = rby))
@@ -166,8 +171,8 @@ class UaStateConnected(UaStateGeneric):
             else:
                 req = self.ua.genRequest('BYE', reason = event.reason)
                 self.ua.lCSeq += 1
-                if redirects != None:
-                    also = SipAlso(redirects[0])
+                if redirect != None:
+                    also = SipAlso(address = redirect)
                     req.appendHeader(SipHeader(name = 'also', body = also))
                 self.ua.global_config['_sip_tm'].newTransaction(req, \
                   laddress = self.ua.source_address, compact = self.ua.compact_sip)

--- a/sippy/UaStateConnected.py
+++ b/sippy/UaStateConnected.py
@@ -56,7 +56,7 @@ class UaStateConnected(UaStateGeneric):
                 self.ua.global_config['_sip_tm'].sendResponse(req.genResponse(400, 'Bad Request', server = self.ua.local_ua))
                 return None
             self.ua.global_config['_sip_tm'].sendResponse(req.genResponse(202, 'Accepted', server = self.ua.local_ua))
-            also = req.getHFBody('refer-to').getUrl().getCopy()
+            also = req.getHFBody('refer-to').getCopy()
             self.ua.equeue.append(CCEventDisconnect(also, rtime = req.rtime, origin = self.ua.origin))
             self.ua.recvEvent(CCEventDisconnect(rtime = req.rtime, origin = self.ua.origin))
             return None
@@ -98,7 +98,7 @@ class UaStateConnected(UaStateGeneric):
             self.ua.global_config['_sip_tm'].sendResponse(req.genResponse(200, 'OK', server = self.ua.local_ua))
             #print 'BYE received in the Connected state, going to the Disconnected state'
             if req.countHFs('also') > 0:
-                also = req.getHFBody('also').getUrl().getCopy()
+                also = req.getHFBody('also').getCopy()
             else:
                 also = None
             event = CCEventDisconnect(also, rtime = req.rtime, origin = self.ua.origin)
@@ -153,8 +153,6 @@ class UaStateConnected(UaStateGeneric):
             redirect = None
             if isinstance(event, CCEventDisconnect):
                 redirect = event.getData()
-                if redirect != None:
-                    redirect = SipAddress(url = redirect)
             elif isinstance(event, CCEventRedirect):
                 redirects = event.getData()
                 if redirects != None:

--- a/sippy/UacStateRinging.py
+++ b/sippy/UacStateRinging.py
@@ -130,7 +130,10 @@ class UacStateRinging(UaStateGeneric):
             self.ua.equeue.append(event)
             return rval
         if code in (301, 302) and resp.countHFs('contact') > 0:
-            scode = (code, reason, body, resp.getHFBody('contact').getUrl().getCopy())
+            scode = (code, reason, body, [ resp.getHFBody('contact').getCopy() ])
+            self.ua.equeue.append(CCEventRedirect(scode, rtime = resp.rtime, origin = self.ua.origin))
+        elif code == 300 and resp.countHFs('contact') > 0:
+            scode = (code, reason, body, resp.getHFBCopys('contact'))
             self.ua.equeue.append(CCEventRedirect(scode, rtime = resp.rtime, origin = self.ua.origin))
         else:
             event = CCEventFail(scode, rtime = resp.rtime, origin = self.ua.origin)

--- a/sippy/UacStateRinging.py
+++ b/sippy/UacStateRinging.py
@@ -130,7 +130,7 @@ class UacStateRinging(UaStateGeneric):
             self.ua.equeue.append(event)
             return rval
         if code in (301, 302) and resp.countHFs('contact') > 0:
-            scode = (code, reason, body, [ resp.getHFBody('contact').getCopy() ])
+            scode = (code, reason, body, (resp.getHFBody('contact').getCopy(),))
             self.ua.equeue.append(CCEventRedirect(scode, rtime = resp.rtime, origin = self.ua.origin))
         elif code == 300 and resp.countHFs('contact') > 0:
             scode = (code, reason, body, resp.getHFBCopys('contact'))

--- a/sippy/UacStateTrying.py
+++ b/sippy/UacStateTrying.py
@@ -148,7 +148,7 @@ class UacStateTrying(UaStateGeneric):
             self.ua.equeue.append(event)
             return rval
         if code in (301, 302) and resp.countHFs('contact') > 0:
-            scode = (code, reason, body, [ resp.getHFBody('contact').getCopy() ])
+            scode = (code, reason, body, (resp.getHFBody('contact').getCopy(),))
             self.ua.equeue.append(CCEventRedirect(scode, rtime = resp.rtime, origin = self.ua.origin))
         elif code == 300 and resp.countHFs('contact') > 0:
             scode = (code, reason, body, resp.getHFBCopys('contact'))

--- a/sippy/UacStateTrying.py
+++ b/sippy/UacStateTrying.py
@@ -28,7 +28,7 @@ from SipAddress import SipAddress
 from SipRoute import SipRoute
 from UaStateGeneric import UaStateGeneric
 from Timeout import TimeoutAbs
-from CCEvents import CCEventRing, CCEventConnect, CCEventFail, CCEventRedirect, CCEventDisconnect
+from CCEvents import CCEventRing, CCEventConnect, CCEventFail, CCEventRedirect, CCEventDisconnect, CCEventPreConnect
 
 class UacStateTrying(UaStateGeneric):
     sname = 'Trying(UAC)'
@@ -147,7 +147,10 @@ class UacStateTrying(UaStateGeneric):
             self.ua.equeue.append(event)
             return rval
         if code in (301, 302) and resp.countHFs('contact') > 0:
-            scode = (code, reason, body, resp.getHFBody('contact').getUrl().getCopy())
+            scode = (code, reason, body, [ resp.getHFBody('contact').getCopy() ])
+            self.ua.equeue.append(CCEventRedirect(scode, rtime = resp.rtime, origin = self.ua.origin))
+        elif code == 300 and resp.countHFs('contact') > 0:
+            scode = (code, reason, body, resp.getHFBCopys('contact'))
             self.ua.equeue.append(CCEventRedirect(scode, rtime = resp.rtime, origin = self.ua.origin))
         else:
             event = CCEventFail(scode, rtime = resp.rtime, origin = self.ua.origin)

--- a/sippy/UacStateUpdating.py
+++ b/sippy/UacStateUpdating.py
@@ -79,7 +79,10 @@ class UacStateUpdating(UaStateGeneric):
             self.ua.equeue.append(event)
             return (UaStateConnected,)
         if code in (301, 302) and resp.countHFs('contact') > 0:
-            scode = (code, reason, body, resp.getHFBody('contact').getUrl().getCopy())
+            scode = (code, reason, body, [ resp.getHFBody('contact').getCopy() ])
+            event = CCEventRedirect(scode, rtime = resp.rtime, origin = self.ua.origin)
+        elif code == 300 and resp.countHFs('contact') > 0:
+            scode = (code, reason, body, resp.getHFBCopys('contact'))
             event = CCEventRedirect(scode, rtime = resp.rtime, origin = self.ua.origin)
         else:
             event = CCEventFail(scode, rtime = resp.rtime, origin = self.ua.origin)

--- a/sippy/UacStateUpdating.py
+++ b/sippy/UacStateUpdating.py
@@ -79,7 +79,7 @@ class UacStateUpdating(UaStateGeneric):
             self.ua.equeue.append(event)
             return (UaStateConnected,)
         if code in (301, 302) and resp.countHFs('contact') > 0:
-            scode = (code, reason, body, [ resp.getHFBody('contact').getCopy() ])
+            scode = (code, reason, body, (resp.getHFBody('contact').getCopy(),))
             event = CCEventRedirect(scode, rtime = resp.rtime, origin = self.ua.origin)
         elif code == 300 and resp.countHFs('contact') > 0:
             scode = (code, reason, body, resp.getHFBCopys('contact'))

--- a/sippy/UasStateRinging.py
+++ b/sippy/UasStateRinging.py
@@ -64,7 +64,7 @@ class UasStateRinging(UaStateGeneric):
                 extra_headers = None
             self.ua.lSDP = body
             if isinstance(event, CCEventConnect):
-                self.ua.sendUasResponse(code, reason, body, [ self.ua.lContact ], ack_wait = False, \
+                self.ua.sendUasResponse(code, reason, body, (self.ua.lContact,), ack_wait = False, \
                   extra_headers = extra_headers)
                 if self.ua.expire_timer != None:
                     self.ua.expire_timer.cancel()
@@ -73,7 +73,7 @@ class UasStateRinging(UaStateGeneric):
                 self.ua.connect_ts = event.rtime
                 return (UaStateConnected, self.ua.conn_cbs, event.rtime, event.origin)
             else:
-                self.ua.sendUasResponse(code, reason, body, [ self.ua.lContact ], ack_wait = True, \
+                self.ua.sendUasResponse(code, reason, body, (self.ua.lContact,), ack_wait = True, \
                   extra_headers = extra_headers)
                 return (UaStateConnected,)
         elif isinstance(event, CCEventRedirect):
@@ -82,7 +82,7 @@ class UasStateRinging(UaStateGeneric):
             if scode == None:
                 scode = (500, 'Failed', None, None)
             elif scode[3] != None:
-                contacts = [ SipContact(address = x) for x in scode[3] ]
+                contacts = tuple(SipContact(address = x) for x in scode[3])
             self.ua.sendUasResponse(scode[0], scode[1], scode[2], contacts)
             if self.ua.expire_timer != None:
                 self.ua.expire_timer.cancel()
@@ -123,7 +123,7 @@ class UasStateRinging(UaStateGeneric):
               server = self.ua.local_ua), lossemul = self.ua.uas_lossemul)
             #print 'BYE received in the Ringing state, going to the Disconnected state'
             if req.countHFs('also') > 0:
-                also = [ req.getHFBody('also').getCopy() ]
+                also = req.getHFBody('also').getUrl().getCopy()
             else:
                 also = None
             event = CCEventDisconnect(also, rtime = req.rtime, origin = self.ua.origin)

--- a/sippy/UasStateRinging.py
+++ b/sippy/UasStateRinging.py
@@ -64,7 +64,7 @@ class UasStateRinging(UaStateGeneric):
                 extra_headers = None
             self.ua.lSDP = body
             if isinstance(event, CCEventConnect):
-                self.ua.sendUasResponse(code, reason, body, self.ua.lContact, ack_wait = False, \
+                self.ua.sendUasResponse(code, reason, body, [ self.ua.lContact ], ack_wait = False, \
                   extra_headers = extra_headers)
                 if self.ua.expire_timer != None:
                     self.ua.expire_timer.cancel()
@@ -73,14 +73,17 @@ class UasStateRinging(UaStateGeneric):
                 self.ua.connect_ts = event.rtime
                 return (UaStateConnected, self.ua.conn_cbs, event.rtime, event.origin)
             else:
-                self.ua.sendUasResponse(code, reason, body, self.ua.lContact, ack_wait = True, \
+                self.ua.sendUasResponse(code, reason, body, [ self.ua.lContact ], ack_wait = True, \
                   extra_headers = extra_headers)
                 return (UaStateConnected,)
         elif isinstance(event, CCEventRedirect):
             scode = event.getData()
+            contacts = None
             if scode == None:
                 scode = (500, 'Failed', None, None)
-            self.ua.sendUasResponse(scode[0], scode[1], scode[2], SipContact(address = SipAddress(url = scode[3])))
+            elif scode[3] != None:
+                contacts = [ SipContact(address = x) for x in scode[3] ]
+            self.ua.sendUasResponse(scode[0], scode[1], scode[2], contacts)
             if self.ua.expire_timer != None:
                 self.ua.expire_timer.cancel()
                 self.ua.expire_timer = None
@@ -120,7 +123,7 @@ class UasStateRinging(UaStateGeneric):
               server = self.ua.local_ua), lossemul = self.ua.uas_lossemul)
             #print 'BYE received in the Ringing state, going to the Disconnected state'
             if req.countHFs('also') > 0:
-                also = req.getHFBody('also').getUrl().getCopy()
+                also = [ req.getHFBody('also').getCopy() ]
             else:
                 also = None
             event = CCEventDisconnect(also, rtime = req.rtime, origin = self.ua.origin)

--- a/sippy/UasStateRinging.py
+++ b/sippy/UasStateRinging.py
@@ -123,7 +123,7 @@ class UasStateRinging(UaStateGeneric):
               server = self.ua.local_ua), lossemul = self.ua.uas_lossemul)
             #print 'BYE received in the Ringing state, going to the Disconnected state'
             if req.countHFs('also') > 0:
-                also = req.getHFBody('also').getUrl().getCopy()
+                also = req.getHFBody('also').getCopy()
             else:
                 also = None
             event = CCEventDisconnect(also, rtime = req.rtime, origin = self.ua.origin)

--- a/sippy/UasStateTrying.py
+++ b/sippy/UasStateTrying.py
@@ -70,7 +70,7 @@ class UasStateTrying(UaStateGeneric):
                 self.ua.no_progress_timer.cancel()
                 self.ua.no_progress_timer = None
             if isinstance(event, CCEventConnect):
-                self.ua.sendUasResponse(code, reason, body, self.ua.lContact, ack_wait = False, \
+                self.ua.sendUasResponse(code, reason, body, [ self.ua.lContact ], ack_wait = False, \
                   extra_headers = extra_headers)
                 if self.ua.expire_timer != None:
                     self.ua.expire_timer.cancel()
@@ -79,14 +79,17 @@ class UasStateTrying(UaStateGeneric):
                 self.ua.connect_ts = event.rtime
                 return (UaStateConnected, self.ua.conn_cbs, event.rtime, event.origin)
             else:
-                self.ua.sendUasResponse(code, reason, body, self.ua.lContact, ack_wait = True, \
+                self.ua.sendUasResponse(code, reason, body, [ self.ua.lContact ], ack_wait = True, \
                   extra_headers = extra_headers)
                 return (UaStateConnected,)
         elif isinstance(event, CCEventRedirect):
             scode = event.getData()
+            contacts = None
             if scode == None:
                 scode = (500, 'Failed', None, None)
-            self.ua.sendUasResponse(scode[0], scode[1], scode[2], SipContact(address = SipAddress(url = scode[3])))
+            elif scode[3] != None:
+                contacts = [ SipContact(address = x) for x in scode[3] ]
+            self.ua.sendUasResponse(scode[0], scode[1], scode[2], contacts)
             if self.ua.expire_timer != None:
                 self.ua.expire_timer.cancel()
                 self.ua.expire_timer = None

--- a/sippy/UasStateTrying.py
+++ b/sippy/UasStateTrying.py
@@ -70,7 +70,7 @@ class UasStateTrying(UaStateGeneric):
                 self.ua.no_progress_timer.cancel()
                 self.ua.no_progress_timer = None
             if isinstance(event, CCEventConnect):
-                self.ua.sendUasResponse(code, reason, body, [ self.ua.lContact ], ack_wait = False, \
+                self.ua.sendUasResponse(code, reason, body, (self.ua.lContact,), ack_wait = False, \
                   extra_headers = extra_headers)
                 if self.ua.expire_timer != None:
                     self.ua.expire_timer.cancel()
@@ -79,7 +79,7 @@ class UasStateTrying(UaStateGeneric):
                 self.ua.connect_ts = event.rtime
                 return (UaStateConnected, self.ua.conn_cbs, event.rtime, event.origin)
             else:
-                self.ua.sendUasResponse(code, reason, body, [ self.ua.lContact ], ack_wait = True, \
+                self.ua.sendUasResponse(code, reason, body, (self.ua.lContact,), ack_wait = True, \
                   extra_headers = extra_headers)
                 return (UaStateConnected,)
         elif isinstance(event, CCEventRedirect):
@@ -88,7 +88,7 @@ class UasStateTrying(UaStateGeneric):
             if scode == None:
                 scode = (500, 'Failed', None, None)
             elif scode[3] != None:
-                contacts = [ SipContact(address = x) for x in scode[3] ]
+                contacts = tuple(SipContact(address = x) for x in scode[3])
             self.ua.sendUasResponse(scode[0], scode[1], scode[2], contacts)
             if self.ua.expire_timer != None:
                 self.ua.expire_timer.cancel()

--- a/sippy/UasStateUpdating.py
+++ b/sippy/UasStateUpdating.py
@@ -60,7 +60,7 @@ class UasStateUpdating(UaStateGeneric):
             self.ua.sendUasResponse(487, 'Request Terminated')
             self.ua.global_config['_sip_tm'].sendResponse(req.genResponse(202, 'Accepted', \
               server = self.ua.local_ua), lossemul = self.ua.uas_lossemul)
-            also = req.getHFBody('refer-to').getUrl().getCopy()
+            also = req.getHFBody('refer-to').getCopy()
             self.ua.equeue.append(CCEventDisconnect(also, rtime = req.rtime, origin = self.ua.origin))
             self.ua.cancelCreditTimer()
             self.ua.disconnect_ts = req.rtime

--- a/sippy/UasStateUpdating.py
+++ b/sippy/UasStateUpdating.py
@@ -60,7 +60,7 @@ class UasStateUpdating(UaStateGeneric):
             self.ua.sendUasResponse(487, 'Request Terminated')
             self.ua.global_config['_sip_tm'].sendResponse(req.genResponse(202, 'Accepted', \
               server = self.ua.local_ua), lossemul = self.ua.uas_lossemul)
-            also = [ req.getHFBody('refer-to').getCopy() ]
+            also = req.getHFBody('refer-to').getUrl().getCopy()
             self.ua.equeue.append(CCEventDisconnect(also, rtime = req.rtime, origin = self.ua.origin))
             self.ua.cancelCreditTimer()
             self.ua.disconnect_ts = req.rtime
@@ -86,7 +86,7 @@ class UasStateUpdating(UaStateGeneric):
                 self.ua.on_local_sdp_change(body, lambda x: self.ua.recvEvent(event))
                 return None
             self.ua.lSDP = body
-            self.ua.sendUasResponse(code, reason, body, [ self.ua.lContact ])
+            self.ua.sendUasResponse(code, reason, body, (self.ua.lContact,))
             return (UaStateConnected,)
         elif isinstance(event, CCEventRedirect):
             scode = event.getData()
@@ -94,7 +94,7 @@ class UasStateUpdating(UaStateGeneric):
             if scode == None:
                 scode = (500, 'Failed', None, None)
             elif scode[3] != None:
-                contacts = [ SipContact(address = x) for x in scode[3] ]
+                contacts = tuple(SipContact(address = x) for x in scode[3])
             self.ua.sendUasResponse(scode[0], scode[1], scode[2], contacts)
             return (UaStateConnected,)
         elif isinstance(event, CCEventFail):


### PR DESCRIPTION
Here is a change needed to support multiple redirect destinations. The patch also contains missed import of CCEventPreConnect in UacStateTrying and support for q= parameter in SipAddress.

Please note that the CCEventRedirect and CCEventDisconnect now carry the redirect destinations as a list of SipAddress-es instead of a single SipURL.

The changed code successfully passes the voiptests.