### PR TITLE
Make the 300 Multiple Choices code consistent with the 301/302 redirect

### DIFF
--- a/sippy/UacStateRinging.py
+++ b/sippy/UacStateRinging.py
@@ -133,7 +133,7 @@ class UacStateRinging(UaStateGeneric):
             scode = (code, reason, body, (resp.getHFBody('contact').getCopy(),))
             self.ua.equeue.append(CCEventRedirect(scode, rtime = resp.rtime, origin = self.ua.origin))
         elif code == 300 and resp.countHFs('contact') > 0:
-            redirects = tuple(x.getCopy() for x in getHFBodys('contact'))
+            redirects = tuple(x.getCopy() for x in resp.getHFBodys('contact'))
             scode = (code, reason, body, redirects)
             self.ua.equeue.append(CCEventRedirect(scode, rtime = resp.rtime, origin = self.ua.origin))
         else:

--- a/sippy/UacStateRinging.py
+++ b/sippy/UacStateRinging.py
@@ -133,7 +133,8 @@ class UacStateRinging(UaStateGeneric):
             scode = (code, reason, body, (resp.getHFBody('contact').getCopy(),))
             self.ua.equeue.append(CCEventRedirect(scode, rtime = resp.rtime, origin = self.ua.origin))
         elif code == 300 and resp.countHFs('contact') > 0:
-            scode = (code, reason, body, resp.getHFBCopys('contact'))
+            redirects = tuple(x.getCopy() for x in getHFBodys('contact'))
+            scode = (code, reason, body, redirects)
             self.ua.equeue.append(CCEventRedirect(scode, rtime = resp.rtime, origin = self.ua.origin))
         else:
             event = CCEventFail(scode, rtime = resp.rtime, origin = self.ua.origin)

--- a/sippy/UacStateRinging.py
+++ b/sippy/UacStateRinging.py
@@ -130,10 +130,10 @@ class UacStateRinging(UaStateGeneric):
             self.ua.equeue.append(event)
             return rval
         if code in (301, 302) and resp.countHFs('contact') > 0:
-            scode = (code, reason, body, (resp.getHFBody('contact').getCopy(),))
+            scode = (code, reason, body, (resp.getHFBody('contact').getUri().getCopy(),))
             self.ua.equeue.append(CCEventRedirect(scode, rtime = resp.rtime, origin = self.ua.origin))
         elif code == 300 and resp.countHFs('contact') > 0:
-            redirects = tuple(x.getCopy() for x in resp.getHFBodys('contact'))
+            redirects = tuple(x.getUri().getCopy() for x in resp.getHFBodys('contact'))
             scode = (code, reason, body, redirects)
             self.ua.equeue.append(CCEventRedirect(scode, rtime = resp.rtime, origin = self.ua.origin))
         else:

--- a/sippy/UacStateTrying.py
+++ b/sippy/UacStateTrying.py
@@ -148,10 +148,10 @@ class UacStateTrying(UaStateGeneric):
             self.ua.equeue.append(event)
             return rval
         if code in (301, 302) and resp.countHFs('contact') > 0:
-            scode = (code, reason, body, (resp.getHFBody('contact').getCopy(),))
+            scode = (code, reason, body, (resp.getHFBody('contact').getUri().getCopy(),))
             self.ua.equeue.append(CCEventRedirect(scode, rtime = resp.rtime, origin = self.ua.origin))
         elif code == 300 and resp.countHFs('contact') > 0:
-            redirects = tuple(x.getCopy() for x in resp.getHFBodys('contact'))
+            redirects = tuple(x.getUri().getCopy() for x in resp.getHFBodys('contact'))
             scode = (code, reason, body, redirects)
             self.ua.equeue.append(CCEventRedirect(scode, rtime = resp.rtime, origin = self.ua.origin))
         else:

--- a/sippy/UacStateTrying.py
+++ b/sippy/UacStateTrying.py
@@ -151,7 +151,8 @@ class UacStateTrying(UaStateGeneric):
             scode = (code, reason, body, (resp.getHFBody('contact').getCopy(),))
             self.ua.equeue.append(CCEventRedirect(scode, rtime = resp.rtime, origin = self.ua.origin))
         elif code == 300 and resp.countHFs('contact') > 0:
-            scode = (code, reason, body, resp.getHFBCopys('contact'))
+            redirects = tuple(x.getCopy() for x in getHFBodys('contact'))
+            scode = (code, reason, body, redirects)
             self.ua.equeue.append(CCEventRedirect(scode, rtime = resp.rtime, origin = self.ua.origin))
         else:
             event = CCEventFail(scode, rtime = resp.rtime, origin = self.ua.origin)

--- a/sippy/UacStateTrying.py
+++ b/sippy/UacStateTrying.py
@@ -151,7 +151,7 @@ class UacStateTrying(UaStateGeneric):
             scode = (code, reason, body, (resp.getHFBody('contact').getCopy(),))
             self.ua.equeue.append(CCEventRedirect(scode, rtime = resp.rtime, origin = self.ua.origin))
         elif code == 300 and resp.countHFs('contact') > 0:
-            redirects = tuple(x.getCopy() for x in getHFBodys('contact'))
+            redirects = tuple(x.getCopy() for x in resp.getHFBodys('contact'))
             scode = (code, reason, body, redirects)
             self.ua.equeue.append(CCEventRedirect(scode, rtime = resp.rtime, origin = self.ua.origin))
         else:

--- a/sippy/UacStateUpdating.py
+++ b/sippy/UacStateUpdating.py
@@ -82,7 +82,8 @@ class UacStateUpdating(UaStateGeneric):
             scode = (code, reason, body, (resp.getHFBody('contact').getCopy(),))
             event = CCEventRedirect(scode, rtime = resp.rtime, origin = self.ua.origin)
         elif code == 300 and resp.countHFs('contact') > 0:
-            scode = (code, reason, body, resp.getHFBCopys('contact'))
+            redirects = tuple(x.getCopy() for x in getHFBodys('contact'))
+            scode = (code, reason, body, redirects)
             event = CCEventRedirect(scode, rtime = resp.rtime, origin = self.ua.origin)
         else:
             event = CCEventFail(scode, rtime = resp.rtime, origin = self.ua.origin)

--- a/sippy/UacStateUpdating.py
+++ b/sippy/UacStateUpdating.py
@@ -82,7 +82,7 @@ class UacStateUpdating(UaStateGeneric):
             scode = (code, reason, body, (resp.getHFBody('contact').getCopy(),))
             event = CCEventRedirect(scode, rtime = resp.rtime, origin = self.ua.origin)
         elif code == 300 and resp.countHFs('contact') > 0:
-            redirects = tuple(x.getCopy() for x in getHFBodys('contact'))
+            redirects = tuple(x.getCopy() for x in resp.getHFBodys('contact'))
             scode = (code, reason, body, redirects)
             event = CCEventRedirect(scode, rtime = resp.rtime, origin = self.ua.origin)
         else:

--- a/sippy/UacStateUpdating.py
+++ b/sippy/UacStateUpdating.py
@@ -79,10 +79,10 @@ class UacStateUpdating(UaStateGeneric):
             self.ua.equeue.append(event)
             return (UaStateConnected,)
         if code in (301, 302) and resp.countHFs('contact') > 0:
-            scode = (code, reason, body, (resp.getHFBody('contact').getCopy(),))
+            scode = (code, reason, body, (resp.getHFBody('contact').getUri().getCopy(),))
             event = CCEventRedirect(scode, rtime = resp.rtime, origin = self.ua.origin)
         elif code == 300 and resp.countHFs('contact') > 0:
-            redirects = tuple(x.getCopy() for x in resp.getHFBodys('contact'))
+            redirects = tuple(x.getUri().getCopy() for x in resp.getHFBodys('contact'))
             scode = (code, reason, body, redirects)
             event = CCEventRedirect(scode, rtime = resp.rtime, origin = self.ua.origin)
         else:


### PR DESCRIPTION
Make the 300 Multiple Choices code consistent with the 301/302 redirect
because the getHFBCopy() is not the same as the getHFBody().getCopy().