### PR TITLE
Adds -x parameter which allows for sip header to radius attributes

### DIFF
--- a/sippy/MyConfigParser.py
+++ b/sippy/MyConfigParser.py
@@ -98,6 +98,8 @@ SUPPORTED_OPTIONS = { \
                              'and "SUBSCRIBE" messages. Address in the format ' \
                              '"host[:port]"'),
  'nat_traversal':     ('B', 'enable NAT traversal for signalling'), \
+ 'auth_extra_header': ('S', 'sip header containing radius parameters to pass ' \
+                            'to authentication request'), \
  'xmpp_b2bua_id':     ('I', 'ID passed to the XMPP socket server')}
 
 class MyConfigParser(RawConfigParser):


### PR DESCRIPTION
This PR adds a new parameter (-x) in the b2bua_radius.py script which allows for the user to specify a SIP Header from which b2bua reads radius attribute/value pairs from. The pairs are being added to the authentication request being created from b2bua.

See related issue #37