### PR TITLE
Adds a parameters= option to the Routing: response from radius

### DIFF
--- a/sippy/B2BRoute.py
+++ b/sippy/B2BRoute.py
@@ -153,6 +153,16 @@ class B2BRoute(object):
                     self.params['outbound_proxy'] = (v, 5060)
                 else:
                     self.params['outbound_proxy'] = (host_port[0], int(host_port[1]))
+            elif a == 'parameters':
+                self.params['radius_parameters'] = []
+
+                pairs = v.split(';')
+
+                for pair in pairs:
+                    [key, _, value] = pair.partition("=")
+
+                    if value != '':
+                        self.params['radius_parameters'].append((key, value))
             else:
                 self.params[a] = v
         if len(extra_headers) > 0:

--- a/sippy/RadiusAccounting.py
+++ b/sippy/RadiusAccounting.py
@@ -69,7 +69,7 @@ class RadiusAccounting(object):
         self.send_start = send_start
 
     def setParams(self, username, caller, callee, h323_cid, sip_cid, remote_ip, \
-      h323_in_cid = None):
+      h323_in_cid = None, radius_parameters = None):
         if caller == None:
             caller = ''
         self._attributes.extend((('User-Name', username), ('Calling-Station-Id', caller), \
@@ -77,8 +77,14 @@ class RadiusAccounting(object):
           ('Acct-Session-Id', sip_cid), ('h323-remote-address', remote_ip)))
         if h323_in_cid != None and h323_in_cid != h323_cid:
             self._attributes.append(('h323-incoming-conf-id', h323_in_cid))
+        if radius_parameters is not None:
+            for attribute, value in radius_parameters:
+                self._attributes.append((attribute, value))
         self.sip_cid = str(sip_cid)
         self.complete = True
+
+    def addAttribute(self, key, value):
+        self._attributes.append((key, value))
 
     def conn(self, ua, rtime, origin):
         if self.crec:

--- a/sippy/b2bua_radius.py
+++ b/sippy/b2bua_radius.py
@@ -280,6 +280,8 @@ class CallController(object):
     def placeOriginate(self, oroute):
         cId, cGUID, cli, cld, body, auth, caller_name = self.eTry.getData()
         cld = oroute.cld
+        radius_parameters = oroute.params.get('radius_parameters', None)
+
         self.huntstop_scodes = oroute.params.get('huntstop_scodes', ())
         if 'static_tr_out' in self.global_config:
             cld = re_replace(self.global_config['static_tr_out'], cld)
@@ -295,10 +297,15 @@ class CallController(object):
               self.global_config.getdefault('alive_acct_int', None))
             self.acctO.ms_precision = self.global_config.getdefault('precise_acct', False)
             self.acctO.setParams(oroute.params.get('bill-to', self.username), oroute.params.get('bill-cli', oroute.cli), \
-              oroute.params.get('bill-cld', cld), self.cGUID, self.cId, host)
+              oroute.params.get('bill-cld', cld), self.cGUID, self.cId, host, radius_parameters=radius_parameters)
         else:
             self.acctO = None
         self.acctA.credit_time = oroute.credit_time
+
+        if radius_parameters:
+            for attribute, value in radius_parameters:
+                self.acctA.addAttribute(attribute, value)
+
         conn_handlers = [self.oConn]
         disc_handlers = []
         if not oroute.forward_on_fail and self.global_config['acct_enable']:


### PR DESCRIPTION
The contents of the parameters= attribute are expected to be key=value pairs that are then sent with each following accounting radius event, back to the radius server.

See also related issue #37 