### PR TITLE
Mulipart fixes

### DIFF
--- a/sippy/MultipartMixBody.py
+++ b/sippy/MultipartMixBody.py
@@ -40,7 +40,8 @@ class MultipartMixBody():
         parts = [p.lstrip() for p in bparts[1:-1]]
         self.parts = []
         for sect in parts:
-            ct, sect = sect.split('\r\n', 1)
+            headers, sect = sect.split('\r\n\r\n', 1) # do hots wos
+            ct = [line for line in  headers.split('\r\n') if "Content-Type" in line][0]
             ct = SipHeader(ct).getBody()
             sect = MsgBody(sect, ct)
             self.parts.append(sect)

--- a/sippy/MultipartMixBody.py
+++ b/sippy/MultipartMixBody.py
@@ -28,7 +28,7 @@ from sippy.SipHeader import SipHeader
 class MultipartMixBody():
     parts = None
     boundary = None
-
+    
     def __init__(self, body = None, ctype = None):
         if body is None:
             return
@@ -39,12 +39,22 @@ class MultipartMixBody():
         assert bparts[-1].strip() == '--'
         parts = [p.lstrip() for p in bparts[1:-1]]
         self.parts = []
+        self.part_headers = []
         for sect in parts:
-            headers, sect = sect.split('\r\n\r\n', 1) # do hots wos
-            ct = [line for line in  headers.split('\r\n') if "Content-Type" in line][0]
-            ct = SipHeader(ct).getBody()
+            headers = []
+            ct = None
+            headersect, sect = sect.split('\r\n\r\n', 1)
+            # parse sub headers
+            for hl in headersect.split('\r\n'):
+                h = SipHeader(hl)
+                if h.name == "content-type":
+                    ct = h.getBody()
+                else:
+                    headers.append(h)
+            # add part
             sect = MsgBody(sect, ct)
             self.parts.append(sect)
+            self.part_headers.append(headers)
         self.boundary = ctype.params["boundary"]
 
     def __str__(self):

--- a/tests/test_Multipart.py
+++ b/tests/test_Multipart.py
@@ -25,7 +25,7 @@ ecall_part0 = (
 
 
 class TestMultipart(unittest.TestCase):
-    def test_run(self):
+    def test_multipart_unsorted_headers(self):
         ct = SipContentType("multipart/mixed;boundary=boundaryZZZ")
         ct.parse()
         got = MsgBody(ecall_body1, mtype=ct)

--- a/tests/test_Multipart.py
+++ b/tests/test_Multipart.py
@@ -1,0 +1,33 @@
+import unittest
+from sippy.MsgBody import MsgBody
+from sippy.MultipartMixBody import MultipartMixBody
+from sippy.SipContentType import SipContentType
+
+# body from RFC 8147 https://datatracker.ietf.org/doc/html/rfc8147
+ecall_body1 = (
+    "--boundaryZZZ\r\n"
+    "Content-Disposition: by-reference\r\n"
+    "Content-Type: application/EmergencyCallData.Control+xml\r\n"
+    "Content-ID: <3456789012@atlanta.example.com>\r\n"
+    "\r\n"
+    '<?xml version="1.0" encoding="UTF-8"?>\r\n'
+    '<EmergencyCallData.Control xmlns="urn:ietf:params:xml:ns:EmergencyCallData:control">\r\n'
+    '<request action="send-data" datatype="eCall.MSD"/>\r\n'
+    "</EmergencyCallData.Control>\r\n"
+    "--boundaryZZZ--\r\n"
+)
+
+
+class TestMultipart(unittest.TestCase):
+    def test_run(self):
+        ct = SipContentType("multipart/mixed;boundary=boundaryZZZ")
+        ct.parse()
+        got = MsgBody(ecall_body1, mtype=ct)
+        got.parse()
+        mp = got.content
+        self.assertEqual(MultipartMixBody, type(mp))
+        self.assertEqual(1, len(mp.parts))
+        p0 = mp.parts[0]
+        self.assertEqual(MsgBody, type(p0))
+        print(p0.mtype)
+        self.assertEqual("application/EmergencyCallData.Control+xml", p0.mtype.localStr())

--- a/tests/test_Multipart.py
+++ b/tests/test_Multipart.py
@@ -31,3 +31,6 @@ class TestMultipart(unittest.TestCase):
         self.assertEqual(MsgBody, type(p0))
         print(p0.mtype)
         self.assertEqual("application/EmergencyCallData.Control+xml", p0.mtype.localStr())
+        h0 = mp.part_headers[0]
+        self.assertEqual("content-disposition", h0[0].name)
+        self.assertEqual("content-id", h0[1].name)

--- a/tests/test_Multipart.py
+++ b/tests/test_Multipart.py
@@ -16,6 +16,12 @@ ecall_body1 = (
     "</EmergencyCallData.Control>\r\n"
     "--boundaryZZZ--\r\n"
 )
+ecall_part0 = (
+    '<?xml version="1.0" encoding="UTF-8"?>\r\n'
+    '<EmergencyCallData.Control xmlns="urn:ietf:params:xml:ns:EmergencyCallData:control">\r\n'
+    '<request action="send-data" datatype="eCall.MSD"/>\r\n'
+    "</EmergencyCallData.Control>\r\n"
+)
 
 
 class TestMultipart(unittest.TestCase):
@@ -29,8 +35,11 @@ class TestMultipart(unittest.TestCase):
         self.assertEqual(1, len(mp.parts))
         p0 = mp.parts[0]
         self.assertEqual(MsgBody, type(p0))
-        print(p0.mtype)
-        self.assertEqual("application/EmergencyCallData.Control+xml", p0.mtype.localStr())
+        #print(p0.mtype)
+        self.assertEqual(
+            "application/EmergencyCallData.Control+xml", p0.mtype.localStr())
         h0 = mp.part_headers[0]
         self.assertEqual("content-disposition", h0[0].name)
         self.assertEqual("content-id", h0[1].name)
+        # check that part body is without headers
+        self.assertEqual(ecall_part0, p0.content)


### PR DESCRIPTION
had the problem that there is multipart payloads out there, where you have multiple headers in a mixed/multipart body where also "Content-Type" is not the first entry (example in the unit test)
Changed the code, so that it remembers all headers, and uses the one with the name content-type to create the MsgBody part. 

Hope thats OK.