### PR TITLE
disallow/skip url encoded CR and LF chars decoding

### DIFF
--- a/sippy/SipURL.py
+++ b/sippy/SipURL.py
@@ -38,6 +38,13 @@ RFC3261_MARK = '-_.!~*\'()'
 
 USERNAME_SAFE = RFC3261_USER_UNRESERVED + RFC3261_MARK
 
+#below function disallow translation of CR and LF chars:
+def safe_unquote(v):
+    r = unquote(v)
+    r = r.replace("\n", "")
+    r = r.replace("\r", "")
+    return r
+
 class SipURL(object):
     scheme = None
     username = None
@@ -110,7 +117,7 @@ class SipURL(object):
             self.port = SipConf.my_port
             self.transport = SipConf.my_transport
         parts = url.split(';')
-        self.username = unquote(parts[0])
+        self.username = safe_unquote(parts[0])
         if len(parts) > 1:
             # parse userparams
             self.userparams = []
@@ -130,7 +137,7 @@ class SipURL(object):
             userdomain = userdomain[:ear] + userdomain_suff
             for header in headers.split('&'):
                 k, v = header.split('=')
-                self.headers[k] = unquote(v)
+                self.headers[k] = safe_unquote(v)
         if ear > 0:
             userpass = userdomain[:ear - 1]
             hostport = userdomain[ear:]
@@ -140,7 +147,7 @@ class SipURL(object):
             uparts = upparts[0].split(';')
             if len(uparts) > 1:
                 self.userparams = uparts[1:]
-            self.username = unquote(uparts[0])
+            self.username = safe_unquote(uparts[0])
         else:
             hostport = userdomain
         parseport = None
@@ -193,7 +200,7 @@ class SipURL(object):
                 self.headers = {}
                 for header in arr[1].split('&'):
                     k, v = header.split('=')
-                    self.headers[k] = unquote(v)
+                    self.headers[k] = safe_unquote(v)
 
     def setParams(self, params):
         self.usertype = None


### PR DESCRIPTION
I have encountered the issue on very old version of sippy b2bua_radius, but I was also able to reproduce it on the latest version.

The main symptom is that b2bua<->radiusclient<->radius server pipeline gets somehow broken, after sippy tries to auth a call with CR-LF-CR-LF sequence in the CLD.
As a result, total mess may happen in the pipeline: radiusclient will "misunderstand" server and vice versa. Just to name a few things I observed: reject will be seen as accept, auth packet will be seen as acct packet, responses from 1 call somehow get into another call.
This sequence may get into CLD through urlencoded data.

Suggested fix/workaround is to skip CR/LF characters during urldecoding. 
The fix has been tested with latest sippy code.

Example how to trigger the issue:
sipp -s '123#456%0D%0A%0D%0A' -m 1 192.168.1.99

Example with latest sippy what the issues looks like (RADIUS server is configured for always accept with same response)
1st few calls go ok:

```
09 Dec 14:23:33.031/1-3373@192.168.1.99/b2bua: sending AAA request:
User-Name                        = '192.168.1.99'
Password                         = 'cisco'
Calling-Station-Id               = 'sipp'
Called-Station-Id                = '123#456

'
call-id                          = '1-3373@192.168.1.99'
h323-remote-address              = '192.168.1.99'
h323-session-protocol            = 'sipv2'

09 Dec 14:23:33.032/1-3373@192.168.1.99/b2bua: AAA request accepted (delay is 0.001), processing response:
Message-Authenticator            = 'S=\260R\012\210\014'
h323-ivr-in                      = 'Routing:123456@10.10.10.10:5060;cli=+123;credit-time=7200;rid=-1;expires=60;np_expires=10'

```


Then accepts are treated as rejects, part of the response with routing is lost (not the worst possible outcome but I've seen worse like explained above):

```
09 Dec 14:26:52.677/1-3390@192.168.1.99/b2bua: sending AAA request:
User-Name                        = '192.168.1.99'
Password                         = 'cisco'
Calling-Station-Id               = 'sipp'
Called-Station-Id                = '123#456

'
call-id                          = '1-3390@192.168.1.99'
h323-remote-address              = '192.168.1.99'
h323-session-protocol            = 'sipv2'

09 Dec 14:26:52.678/1-3390@192.168.1.99/b2bua: AAA request rejected (delay is 0.001), processing response:
Message-Authenticator            = '\037\3451\016\342)\0031\367\232\025Z\037\225r\231'



09 Dec 14:27:35.383/1-3395@192.168.1.99/b2bua: sending AAA request:
User-Name                        = '192.168.1.99'
Password                         = 'cisco'
Calling-Station-Id               = 'sipp'
Called-Station-Id                = '123#456

'
call-id                          = '1-3395@192.168.1.99'
h323-remote-address              = '192.168.1.99'
h323-session-protocol            = 'sipv2'

09 Dec 14:27:35.389/1-3395@192.168.1.99/b2bua: AAA request rejected (delay is 0.006), processing response:
Message-Authenticator            = '\274\310\235\347\212\345\352\202\222\026\026'Y\317ef'
```

After the suggested fix/workaround, the issue is not happening anymore:

```
09 Dec 14:46:34.591/1-3505@192.168.1.99/b2bua: sending AAA request:
User-Name                        = '192.168.1.99'
Password                         = 'cisco'
Calling-Station-Id               = 'sipp'
Called-Station-Id                = '123#456'
call-id                          = '1-3505@192.168.1.99'
h323-remote-address              = '192.168.1.99'
h323-session-protocol            = 'sipv2'

09 Dec 14:46:34.592/1-3505@192.168.1.99/b2bua: AAA request accepted (delay is 0.001), processing response:
Message-Authenticator            = ']\2745\316f\354o\320"\320\004\270\370\344\355\310'
h323-ivr-in                      = 'Routing:123456@10.10.10.10:5060;cli=+123;credit-time=7200;rid=-1;expires=60;np_expires=10'
```




 